### PR TITLE
feat: configurable AI backend and auto-detect subcommands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ PROGRAMS_WITH_SUBCOMMANDS := flowctl nixpacks cody uv launchctl aiautocommit ale
 PROGRAMS_WITH_MANPAGES := entr
 
 DEFAULT_HELP_COMMAND ?= --help
+PYTHON ?= python3
 AI_CLI ?= gemini
 AI_MODEL ?=
 AI_MODEL_FLAG ?= -m
@@ -22,18 +23,24 @@ endif
 all_completions: $(addprefix completions/_,$(PROGRAMS_WITHOUT_SUBCOMMANDS) $(PROGRAMS_WITH_SUBCOMMANDS) $(PROGRAMS_WITH_MANPAGES))
 
 completions/_%: completion_prompt.md generate_completion.py
-	# Buffer output to a file to prevent BrokenPipeError if gemini is slow to read stdin
-	# This decouples the help generation from the API call
+	@# Buffer output to a file to prevent BrokenPipeError if gemini is slow to read stdin
+	@# This decouples the help generation from the API call
 	@if command -v $* >/dev/null 2>&1; then \
+		binary_path=$$(command -v $*); \
+		echo "Generating completion for $* ($$binary_path) using $(AI_CLI)$${AI_MODEL:+ model $(AI_MODEL)}..."; \
 		mkdir -p tmp; \
 		if echo "$(PROGRAMS_WITH_SUBCOMMANDS)" | grep -q "\b$*\b"; then \
-			python explore_program.py $(AI_ARGS) $* > tmp/$*.help; \
-			python generate_completion.py $(AI_ARGS) $* tmp/$*.help > completions/_$*; \
+			echo "  Exploring subcommands..."; \
+			$(PYTHON) explore_program.py $(AI_ARGS) $* > tmp/$*.help; \
+			echo "  Generating completion from explored help..."; \
+			$(PYTHON) generate_completion.py $(AI_ARGS) $* tmp/$*.help > completions/_$*; \
 			rm tmp/$*.help; \
 		elif echo "$(PROGRAMS_WITH_MANPAGES)" | grep -q "\b$*\b"; then \
-			man $* | python generate_completion.py $(AI_ARGS) $* > completions/_$*; \
+			echo "  Generating completion from manpage..."; \
+			man $* | $(PYTHON) generate_completion.py $(AI_ARGS) $* > completions/_$*; \
 		else \
-			$* $(DEFAULT_HELP_COMMAND) 2>&1 | python generate_completion.py $(AI_ARGS) $* > completions/_$*; \
+			echo "  Generating completion from --help output..."; \
+			$* $(DEFAULT_HELP_COMMAND) 2>&1 | $(PYTHON) generate_completion.py $(AI_ARGS) $* > completions/_$*; \
 		fi; \
 		if [ ! -s completions/_$* ]; then \
 			rm -f completions/_$*; \
@@ -44,6 +51,15 @@ completions/_%: completion_prompt.md generate_completion.py
 				echo >&2 "Error: Generated completion for $* failed validation. Removing file."; \
 				exit 1; \
 			fi; \
+			tool_version=$$($* --version 2>/dev/null | head -1 || echo "unknown"); \
+			gen_date=$$(date +%Y-%m-%d); \
+			{ echo "#compdef $*"; \
+			  echo "# Generated from: $$tool_version ($$binary_path)"; \
+			  echo "# Generated on: $$gen_date"; \
+			  echo "# AI: $(AI_CLI)$${AI_MODEL:+ ($(AI_MODEL))}"; \
+			  tail -n +2 completions/_$*; } > completions/_$*.tmp && \
+			mv completions/_$*.tmp completions/_$*; \
+			echo "  Written to completions/_$*"; \
 		fi; \
 	else \
 		echo >&2 "Warning: $* is not installed or not in PATH. Skipping."; \

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,14 @@ PROGRAMS_WITH_SUBCOMMANDS := flowctl nixpacks cody uv launchctl aiautocommit ale
 PROGRAMS_WITH_MANPAGES := entr
 
 DEFAULT_HELP_COMMAND ?= --help
+AI_CLI ?= gemini
+AI_MODEL ?=
+AI_MODEL_FLAG ?= -m
+
+AI_ARGS := --cli $(AI_CLI)
+ifneq ($(AI_MODEL),)
+AI_ARGS += --model $(AI_MODEL) --model-flag $(AI_MODEL_FLAG)
+endif
 
 .DEFAULT_GOAL := all_completions
 
@@ -19,13 +27,13 @@ completions/_%: completion_prompt.md generate_completion.py
 	@if command -v $* >/dev/null 2>&1; then \
 		mkdir -p tmp; \
 		if echo "$(PROGRAMS_WITH_SUBCOMMANDS)" | grep -q "\b$*\b"; then \
-			python explore_program.py $* > tmp/$*.help; \
-			python generate_completion.py $* tmp/$*.help > completions/_$*; \
+			python explore_program.py $(AI_ARGS) $* > tmp/$*.help; \
+			python generate_completion.py $(AI_ARGS) $* tmp/$*.help > completions/_$*; \
 			rm tmp/$*.help; \
 		elif echo "$(PROGRAMS_WITH_MANPAGES)" | grep -q "\b$*\b"; then \
-			man $* | python generate_completion.py $* > completions/_$*; \
+			man $* | python generate_completion.py $(AI_ARGS) $* > completions/_$*; \
 		else \
-			$* $(DEFAULT_HELP_COMMAND) 2>&1 | python generate_completion.py $* > completions/_$*; \
+			$* $(DEFAULT_HELP_COMMAND) 2>&1 | python generate_completion.py $(AI_ARGS) $* > completions/_$*; \
 		fi; \
 		if [ ! -s completions/_$* ]; then \
 			rm -f completions/_$*; \

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,6 @@
 SHELL := zsh
 
-NO_SUBCOMMAND_PROMPT := "Generate zsh completion for all arguments listed in this '--help' output. Only return the shell script contents (no other output) without a markdown block."
-PROGRAMS_WITHOUT_SUBCOMMANDS := sops ncdu tre vitest eslint fastmod ipython fzf zq pytest q dokku lnav act localias markdown-extract micro difft
-PROGRAMS_WITH_SUBCOMMANDS := flowctl nixpacks cody uv launchctl aiautocommit alembic security foreman mcpm gemini railpack
+PROGRAMS := sops ncdu tre vitest eslint fastmod ipython fzf zq pytest q dokku lnav act localias markdown-extract micro difft flowctl nixpacks cody uv launchctl aiautocommit alembic security foreman mcpm gemini railpack
 
 # some programs don't have helpful --help output, so we use manpages instead
 PROGRAMS_WITH_MANPAGES := entr
@@ -11,36 +9,35 @@ DEFAULT_HELP_COMMAND ?= --help
 PYTHON ?= python3
 AI_CLI ?= gemini
 AI_MODEL ?=
-AI_MODEL_FLAG ?= -m
+AI_MODEL_FLAG ?= --model
 
 AI_ARGS := --cli $(AI_CLI)
 ifneq ($(AI_MODEL),)
-AI_ARGS += --model $(AI_MODEL) --model-flag $(AI_MODEL_FLAG)
+AI_ARGS += --model $(AI_MODEL)
+export AI_MODEL_FLAG
 endif
 
 .DEFAULT_GOAL := all_completions
 
-all_completions: $(addprefix completions/_,$(PROGRAMS_WITHOUT_SUBCOMMANDS) $(PROGRAMS_WITH_SUBCOMMANDS) $(PROGRAMS_WITH_MANPAGES))
+all_completions: $(addprefix completions/_,$(PROGRAMS) $(PROGRAMS_WITH_MANPAGES))
 
 completions/_%: completion_prompt.md generate_completion.py
 	@# Buffer output to a file to prevent BrokenPipeError if gemini is slow to read stdin
 	@# This decouples the help generation from the API call
 	@if command -v $* >/dev/null 2>&1; then \
+		start_time=$$(date +%s); \
 		binary_path=$$(command -v $*); \
 		echo "Generating completion for $* ($$binary_path) using $(AI_CLI)$${AI_MODEL:+ model $(AI_MODEL)}..."; \
 		mkdir -p tmp; \
-		if echo "$(PROGRAMS_WITH_SUBCOMMANDS)" | grep -q "\b$*\b"; then \
-			echo "  Exploring subcommands..."; \
-			$(PYTHON) explore_program.py $(AI_ARGS) $* > tmp/$*.help; \
-			echo "  Generating completion from explored help..."; \
-			$(PYTHON) generate_completion.py $(AI_ARGS) $* tmp/$*.help > completions/_$*; \
-			rm tmp/$*.help; \
-		elif echo "$(PROGRAMS_WITH_MANPAGES)" | grep -q "\b$*\b"; then \
+		if echo "$(PROGRAMS_WITH_MANPAGES)" | grep -q "\b$*\b"; then \
 			echo "  Generating completion from manpage..."; \
 			man $* | $(PYTHON) generate_completion.py $(AI_ARGS) $* > completions/_$*; \
 		else \
-			echo "  Generating completion from --help output..."; \
-			$* $(DEFAULT_HELP_COMMAND) 2>&1 | $(PYTHON) generate_completion.py $(AI_ARGS) $* > completions/_$*; \
+			echo "  Exploring help and subcommands..."; \
+			$(PYTHON) explore_program.py $(AI_ARGS) $* > tmp/$*.help; \
+			echo "  Generating completion..."; \
+			$(PYTHON) generate_completion.py $(AI_ARGS) $* tmp/$*.help > completions/_$*; \
+			rm tmp/$*.help; \
 		fi; \
 		if [ ! -s completions/_$* ]; then \
 			rm -f completions/_$*; \
@@ -51,7 +48,8 @@ completions/_%: completion_prompt.md generate_completion.py
 				echo >&2 "Error: Generated completion for $* failed validation. Removing file."; \
 				exit 1; \
 			fi; \
-			tool_version=$$($* --version 2>/dev/null | head -1 || echo "unknown"); \
+			tool_version=$$($* --version 2>/dev/null | head -1); \
+			tool_version=$${tool_version:-unknown}; \
 			gen_date=$$(date +%Y-%m-%d); \
 			{ echo "#compdef $*"; \
 			  echo "# Generated from: $$tool_version ($$binary_path)"; \
@@ -59,14 +57,16 @@ completions/_%: completion_prompt.md generate_completion.py
 			  echo "# AI: $(AI_CLI)$${AI_MODEL:+ ($(AI_MODEL))}"; \
 			  tail -n +2 completions/_$*; } > completions/_$*.tmp && \
 			mv completions/_$*.tmp completions/_$*; \
-			echo "  Written to completions/_$*"; \
+			end_time=$$(date +%s); \
+			elapsed=$$((end_time - start_time)); \
+			echo "  Written to completions/_$* ($${elapsed}s)"; \
 		fi; \
 	else \
 		echo >&2 "Warning: $* is not installed or not in PATH. Skipping."; \
 	fi
 
 clean:
-	rm -f $(addprefix completions/_,$(PROGRAMS_WITHOUT_SUBCOMMANDS) $(PROGRAMS_WITH_SUBCOMMANDS) $(PROGRAMS_WITH_MANPAGES))
+	rm -f $(addprefix completions/_,$(PROGRAMS) $(PROGRAMS_WITH_MANPAGES))
 	rm -rf tmp/
 
 update-local:

--- a/README.md
+++ b/README.md
@@ -24,20 +24,20 @@ I've checked the AI generated completions against this tool and it works quite w
 
 ### Generating Completions
 
-The `Makefile` orchestrates exploration and generation. The `completions/_` pattern rule accepts any program name — if the binary is in your PATH, it will generate a completion for it:
+The `Makefile` orchestrates exploration and generation. It automatically detects whether a program has subcommands and explores them recursively. The `completions/_` pattern rule accepts any program name — if the binary is in your PATH, it will generate a completion for it:
 
 ```shell
 # Generate completion for any installed program
 make completions/_claude
 
-# Programs in the PROGRAMS_WITH_SUBCOMMANDS list get deeper exploration
-make completions/_aiautocommit
-```
-
-To build all pre-configured completions:
-
-```shell
+# Build all pre-configured completions
 make
+
+# Force regeneration of an existing completion
+make -B completions/_claude
+
+# Force regeneration of all completions
+make -B
 ```
 
 ### Configuring the AI Backend
@@ -49,17 +49,29 @@ By default, the [Gemini CLI](https://github.com/google-gemini/gemini-cli) is use
 make completions/_sops AI_MODEL=gemini-2.5-pro
 
 # Use Claude instead of Gemini
-make completions/_sops AI_CLI=claude AI_MODEL=sonnet AI_MODEL_FLAG=--model
+make completions/_sops AI_CLI=claude AI_MODEL=sonnet
 
 # Build all completions with a different backend
-make AI_CLI=claude AI_MODEL=sonnet AI_MODEL_FLAG=--model
+make AI_CLI=claude AI_MODEL=sonnet
 ```
 
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `AI_CLI` | `gemini` | The LLM CLI binary to invoke |
 | `AI_MODEL` | *(empty — uses CLI default)* | Model name to pass to the CLI |
-| `AI_MODEL_FLAG` | `-m` | The flag syntax for model selection (e.g., `-m` for Gemini, `--model` for Claude) |
+| `AI_MODEL_FLAG` | `--model` | The flag syntax for model selection (e.g., `--model` works for both Gemini and Claude) |
+
+#### Benchmark: `ls` completion generation
+
+| Backend | Model | Time |
+|---------|-------|------|
+| Claude | Opus | 47s |
+| Claude | Sonnet | 61s |
+| Gemini | default | 216s |
+
+#### Compatibility Notes
+
+The AI CLI must support a prompt as a positional argument (or via `-p`) and accept context on stdin. CLIs that don't follow this pattern (e.g., Codex, which uses `-p` for config profiles and doesn't accept piped stdin) are not currently supported.
 
 ### Running Scripts Directly
 

--- a/README.md
+++ b/README.md
@@ -22,13 +22,67 @@ I've checked the AI generated completions against this tool and it works quite w
 
 ## Development
 
-### Additional Completions
+### Generating Completions
 
-Just modify the `Makefile` run `make` and test the output. Then, please submit a PR!
+The `Makefile` orchestrates exploration and generation. The `completions/_` pattern rule accepts any program name — if the binary is in your PATH, it will generate a completion for it:
 
-To focus on building a single completion run `make completions/_aiautocommit`
+```shell
+# Generate completion for any installed program
+make completions/_claude
 
-Note that [Cody](http://cody.dev) is used for generating the completions since they have a nice CLI tool.
+# Programs in the PROGRAMS_WITH_SUBCOMMANDS list get deeper exploration
+make completions/_aiautocommit
+```
+
+To build all pre-configured completions:
+
+```shell
+make
+```
+
+### Configuring the AI Backend
+
+By default, the [Gemini CLI](https://github.com/google-gemini/gemini-cli) is used with its default model. You can override the AI CLI, model, and model flag syntax via Makefile variables:
+
+```shell
+# Use a specific Gemini model
+make completions/_sops AI_MODEL=gemini-2.5-pro
+
+# Use Claude instead of Gemini
+make completions/_sops AI_CLI=claude AI_MODEL=sonnet AI_MODEL_FLAG=--model
+
+# Build all completions with a different backend
+make AI_CLI=claude AI_MODEL=sonnet AI_MODEL_FLAG=--model
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `AI_CLI` | `gemini` | The LLM CLI binary to invoke |
+| `AI_MODEL` | *(empty — uses CLI default)* | Model name to pass to the CLI |
+| `AI_MODEL_FLAG` | `-m` | The flag syntax for model selection (e.g., `-m` for Gemini, `--model` for Claude) |
+
+### Running Scripts Directly
+
+The Python scripts also accept these options directly and support environment variables as fallbacks:
+
+```shell
+# Explore a program's help and subcommands
+uv run python explore_program.py --cli gemini --model gemini-2.5-pro myprogram
+
+# Generate a completion from a help file
+uv run python generate_completion.py --cli claude --model sonnet --model-flag --model myprogram help.md
+
+# Pipe help output directly (uses defaults)
+myprogram --help 2>&1 | uv run python generate_completion.py myprogram
+```
+
+Environment variables `AI_CLI`, `AI_MODEL`, and `AI_MODEL_FLAG` are also respected when flags are not provided.
+
+### Adding New Completions
+
+1. Add the program name to the appropriate list in the `Makefile` (`PROGRAMS_WITHOUT_SUBCOMMANDS`, `PROGRAMS_WITH_SUBCOMMANDS`, or `PROGRAMS_WITH_MANPAGES`)
+2. Run `make completions/_<program>`
+3. Test the output, then submit a PR
 
 ### Local Testing
 
@@ -38,6 +92,11 @@ Want to test out a completion locally?
 fpath+=./completions
 autoload -Uz compinit && compinit
 ```
+
+## Authors
+
+- [Michael Bianco](https://github.com/iloveitaly) — original project
+- [Stephen Feather](https://github.com/stephenfeather) — configurable AI backend, documentation (with the help of [@claude](https://claude.ai))
 
 ## TODO
 

--- a/explore_program.py
+++ b/explore_program.py
@@ -1,8 +1,9 @@
-import subprocess
-import sys
+import argparse
 import json
 import logging
 import os
+import subprocess
+import sys
 
 # Set up logging
 logging.basicConfig(
@@ -31,7 +32,16 @@ def run_help_command(command):
         return output
 
 
-def get_subcommands(program, args):
+def build_llm_cmd(cli, model_flag, model, prompt):
+    """Build the LLM CLI command list."""
+    cmd = [cli]
+    if model:
+        cmd.extend([model_flag, model])
+    cmd.extend(["-p", prompt])
+    return cmd
+
+
+def get_subcommands(program, args, cli, model_flag, model):
     command = [program] + args + ["--help"]
     help_output = run_help_command(command)
 
@@ -52,15 +62,10 @@ def get_subcommands(program, args):
     )
 
     logging.info("Sending help output to LLM for analysis")
+    cmd = build_llm_cmd(cli, model_flag, model, llm_prompt)
     try:
         llm_result = subprocess.run(
-            [
-                "gemini",
-                "-m",
-                "gemini-3-pro-preview",
-                "-p",
-                llm_prompt,
-            ],
+            cmd,
             input=help_output,
             capture_output=True,
             text=True,
@@ -81,7 +86,7 @@ def get_subcommands(program, args):
         return []
 
 
-def explore_command(program, args=None, depth=0):
+def explore_command(program, cli, model_flag, model, args=None, depth=0):
     if args is None:
         args = []
 
@@ -96,24 +101,31 @@ def explore_command(program, args=None, depth=0):
     markdown = f"{'#' * (depth + 2)} {' '.join([program] + args)}\n\n"
     markdown += "```\n" + help_output.strip() + "\n```\n\n"
 
-    subcommands = get_subcommands(program, args)
+    subcommands = get_subcommands(program, args, cli, model_flag, model)
 
     for subcommand in subcommands:
-        markdown += explore_command(program, args + [subcommand], depth + 1)
+        markdown += explore_command(program, cli, model_flag, model, args + [subcommand], depth + 1)
 
     return markdown
 
 
-def main():
-    if len(sys.argv) != 2:
-        logging.error("Invalid number of arguments")
-        print("Usage: python explore_program.py <program_name>", file=sys.stderr)
-        sys.exit(1)
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Explore a program's help output and subcommands using an LLM CLI"
+    )
+    parser.add_argument("program_name", help="Name of the program to explore")
+    parser.add_argument("--cli", default=os.environ.get("AI_CLI", "gemini"), help="LLM CLI binary (default: gemini)")
+    parser.add_argument("--model", default=os.environ.get("AI_MODEL", ""), help="Model name (omit to use CLI default)")
+    parser.add_argument("--model-flag", default=os.environ.get("AI_MODEL_FLAG", "-m"), help="Flag syntax for model selection (default: -m)")
+    return parser.parse_args()
 
-    program = sys.argv[1]
-    logging.info(f"Starting exploration of program: {program}")
-    markdown = f"# {program} Help\n\n"
-    markdown += explore_command(program)
+
+def main():
+    args = parse_args()
+    logging.info(f"Starting exploration of program: {args.program_name}")
+
+    markdown = f"# {args.program_name} Help\n\n"
+    markdown += explore_command(args.program_name, args.cli, args.model_flag, args.model)
 
     print(markdown)
     logging.info("Exploration completed")

--- a/explore_program.py
+++ b/explore_program.py
@@ -116,8 +116,9 @@ def parse_args():
     parser.add_argument("program_name", help="Name of the program to explore")
     parser.add_argument("--cli", default=os.environ.get("AI_CLI", "gemini"), help="LLM CLI binary (default: gemini)")
     parser.add_argument("--model", default=os.environ.get("AI_MODEL", ""), help="Model name (omit to use CLI default)")
-    parser.add_argument("--model-flag", default=os.environ.get("AI_MODEL_FLAG", "-m"), help="Flag syntax for model selection (default: -m)")
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.model_flag = os.environ.get("AI_MODEL_FLAG", "--model")
+    return args
 
 
 def main():

--- a/generate_completion.py
+++ b/generate_completion.py
@@ -1,6 +1,8 @@
-import sys
-import subprocess
+import argparse
 import os
+import subprocess
+import sys
+
 
 def clean_output(output):
     """
@@ -10,71 +12,80 @@ def clean_output(output):
     output = output.strip()
     if "```" in output:
         parts = output.split("```")
-        # Usually the code is in the second part (index 1)
         if len(parts) >= 3:
             code_block = parts[1]
-            # Remove language identifier line if it exists (e.g. "zsh")
             if "\n" in code_block:
                 first_line_end = code_block.find("\n")
                 first_line = code_block[:first_line_end].strip()
-                # If the first line is just a language name or empty, skip it
                 if not first_line or "zsh" in first_line or "sh" in first_line:
                     return code_block[first_line_end+1:].strip()
             return code_block.strip()
     return output
 
-def main():
-    if len(sys.argv) < 2:
-        print("Usage: python generate_completion.py <program_name> [help_file]", file=sys.stderr)
-        sys.exit(1)
 
-    program_name = sys.argv[1]
-    help_file = sys.argv[2] if len(sys.argv) > 2 else None
-
-    # Read the prompt
+def read_prompt(program_name):
+    """Read and prepare the completion prompt template."""
     try:
         with open("completion_prompt.md", "r") as f:
-            prompt = f.read()
+            return f.read().replace("<command>", program_name)
     except FileNotFoundError:
         print("Error: completion_prompt.md not found.", file=sys.stderr)
         sys.exit(1)
 
-    # Replace placeholder if any (though currently the prompt is generic)
-    prompt = prompt.replace("<command>", program_name)
 
-    # Read help content
+def read_help_content(help_file):
+    """Read help content from file or stdin."""
     if help_file:
         try:
             with open(help_file, "r") as f:
-                help_content = f.read()
+                return f.read()
         except FileNotFoundError:
             print(f"Error: Help file {help_file} not found.", file=sys.stderr)
             sys.exit(1)
-    else:
-        # Read from stdin
-        help_content = sys.stdin.read()
+    return sys.stdin.read()
 
-    # Call Gemini
-    # We pass the prompt as the "prompt" argument and help_content as stdin (context)
+
+def build_cmd(cli, model_flag, model, prompt):
+    """Build the CLI command list."""
+    cmd = [cli]
+    if model:
+        cmd.extend([model_flag, model])
+    cmd.append(prompt)
+    return cmd
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Generate a Zsh completion script using an LLM CLI"
+    )
+    parser.add_argument("program_name", help="Name of the program to generate completions for")
+    parser.add_argument("help_file", nargs="?", default=None, help="Path to help file (reads stdin if omitted)")
+    parser.add_argument("--cli", default=os.environ.get("AI_CLI", "gemini"), help="LLM CLI binary (default: gemini)")
+    parser.add_argument("--model", default=os.environ.get("AI_MODEL", ""), help="Model name (omit to use CLI default)")
+    parser.add_argument("--model-flag", default=os.environ.get("AI_MODEL_FLAG", "-m"), help="Flag syntax for model selection (default: -m)")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    prompt = read_prompt(args.program_name)
+    help_content = read_help_content(args.help_file)
+    cmd = build_cmd(args.cli, args.model_flag, args.model, prompt)
+
     try:
-        # We use the -p flag or positional argument. 
-        # Using positional argument is safer for recent gemini CLI versions.
-        cmd = ["gemini", "-m", "gemini-3-pro-preview", prompt]
-        
         result = subprocess.run(
             cmd,
             input=help_content,
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
-        
         print(clean_output(result.stdout))
-
     except subprocess.CalledProcessError as e:
-        print(f"Error calling gemini: {e}", file=sys.stderr)
+        print(f"Error calling {args.cli}: {e}", file=sys.stderr)
         print(f"Stderr: {e.stderr}", file=sys.stderr)
         sys.exit(1)
+
 
 if __name__ == "__main__":
     main()

--- a/generate_completion.py
+++ b/generate_completion.py
@@ -62,8 +62,9 @@ def parse_args():
     parser.add_argument("help_file", nargs="?", default=None, help="Path to help file (reads stdin if omitted)")
     parser.add_argument("--cli", default=os.environ.get("AI_CLI", "gemini"), help="LLM CLI binary (default: gemini)")
     parser.add_argument("--model", default=os.environ.get("AI_MODEL", ""), help="Model name (omit to use CLI default)")
-    parser.add_argument("--model-flag", default=os.environ.get("AI_MODEL_FLAG", "-m"), help="Flag syntax for model selection (default: -m)")
-    return parser.parse_args()
+    args = parser.parse_args()
+    args.model_flag = os.environ.get("AI_MODEL_FLAG", "--model")
+    return args
 
 
 def main():


### PR DESCRIPTION
## Summary

- **Configurable AI backend**: Replace hardcoded Gemini CLI and model with Makefile variables (`AI_CLI`, `AI_MODEL`, `AI_MODEL_FLAG`). Both Python scripts accept `--cli` and `--model` args with env var fallbacks, enabling Claude or other LLM CLIs alongside Gemini.
- **Auto-detect subcommands**: Removed the manual `PROGRAMS_WITH_SUBCOMMANDS` / `PROGRAMS_WITHOUT_SUBCOMMANDS` split. All programs now go through `explore_program.py` which uses AI to detect subcommands automatically.
- **Progress output**: Shows the resolved binary path, AI backend, step-by-step progress, elapsed time, and writes a version stamp header into each completion file.
- **Python 3 compatibility**: Defaults `PYTHON` to `python3` for macOS.

## Benchmark: `ls` completion

| Backend | Model | Time |
|---------|-------|------|
| Claude | Opus | 47s |
| Claude | Sonnet | 61s |
| Gemini | default | 216s |

## Test plan

- [x] `make -B completions/_ls` with default Gemini backend
- [x] `make -B completions/_ls AI_CLI=claude AI_MODEL=sonnet`
- [x] `make -B completions/_ls AI_CLI=claude AI_MODEL=opus`
- [x] Verified version stamp header in output
- [x] Verified subcommand auto-detection (ls has none, correctly detected)
- [x] Verified `make completions/_ls` skips when up to date
- [x] Verified `make -B completions/_ls` forces regeneration